### PR TITLE
Implement JukeboxAreaController and Backend Integration Tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,63 @@
+name: Deploy
+on: # Controls when the action will run.
+  # Triggers the workflow on push or pull request events but only for the master branch. If you want to trigger the action on other branches, add here
+  push:
+    branches: [main]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build-and-push-town-service-to-ghcr:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build town service image
+        run: docker build -f Dockerfile.townService -t ghcr.io/cs-490-project/covey_town_town_service:latest .
+      # see https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-a-registry-using-a-personal-access-token
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push town service image
+        run: docker push ghcr.io/cs-490-project/covey_town_town_service:latest
+  build-and-push-frontend-to-ghcr:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build frontend image
+        run: docker build -f Dockerfile.frontend -t ghcr.io/cs-490-project/covey_town_frontend:latest . --build-arg NEXT_PUBLIC_TOWNS_SERVICE_URL=https://coveytownservice.dogbuilt.net
+      # see https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-a-registry-using-a-personal-access-token
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Push frontend image
+        run: docker push ghcr.io/cs-490-project/covey_town_frontend:latest
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs:
+      [build-and-push-town-service-to-ghcr, build-and-push-frontend-to-ghcr]
+    steps:
+      - name: executing remote ssh commands using password
+        uses: appleboy/ssh-action@2ead5e36573f08b82fbfce1504f1a4b05a647c6f
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            podman pull ghcr.io/cs-490-project/covey_town_town_service
+            podman pull ghcr.io/cs-490-project/covey_town_frontend
+            systemctl --user restart covey-town-town-service
+            systemctl --user restart covey-town-frontend
+            podman container prune -f
+            podman image prune -f

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ on: # Controls when the action will run.
 jobs:
   build-and-test: #
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,4 +1,4 @@
-FROM node:18-buster-slim
+FROM node:18-bookworm-slim
 RUN apt-get update || : && apt-get install python3 build-essential libpango1.0-dev libcairo2-dev libjpeg-dev libgif-dev -y && rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -10,10 +10,10 @@ RUN rm -rf node_modules
 RUN npm ci
 ENV GENERATE_SOURCEMAP false
 ENV NODE_OPTIONS --max_old_space_size=2048
-ENV NODE_ENV production
 ENV PORT 80
 EXPOSE 80
 ARG NEXT_PUBLIC_TOWNS_SERVICE_URL
 ENV NEXT_PUBLIC_TOWNS_SERVICE_URL=${NEXT_PUBLIC_TOWNS_SERVICE_URL}
+RUN npm run client
 RUN npm run build
 CMD [ "npm", "start" ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -66,7 +66,7 @@
     "test-watch": "jest --watch",
     "eject": "react-scripts eject",
     "format": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx ",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "client": "openapi --input ../shared/generated/swagger.json --output ./src/generated/client --client axios --name TownsServiceClient",
     "stryker-prepare": "replace-in-file '/../../..//g' '../../../../../' src/types/CoveyTownSocket.d.ts --isRegex",
     "stryker": "stryker run"

--- a/frontend/src/classes/TownController.ts
+++ b/frontend/src/classes/TownController.ts
@@ -1,9 +1,8 @@
 import assert from 'assert';
-import { generateKey } from 'crypto';
 import EventEmitter from 'events';
 import _ from 'lodash';
 import { nanoid } from 'nanoid';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { io } from 'socket.io-client';
 import TypedEmitter from 'typed-emitter';
 import Interactable from '../components/Town/Interactable';

--- a/shared/types/CoveyTownSocket.d.ts
+++ b/shared/types/CoveyTownSocket.d.ts
@@ -17,11 +17,30 @@ export type TownJoinResponse = {
   interactables: TypedInteractable[];
 }
 
-export type InteractableType = 'ConversationArea' | 'ViewingArea' | 'TicTacToeArea' | 'ConnectFourArea';
+export type InteractableType = 'ConversationArea' | 'ViewingArea' | 'TicTacToeArea' | 'ConnectFourArea' | 'JukeboxArea';
 export interface Interactable {
   type: InteractableType;
   id: InteractableID;
   occupants: PlayerID[];
+}
+
+/*
+ * Type that represents a single song used by backend and frontend
+ * Add more parameters as needed
+*/
+export type Song = {
+  url: string;
+  thumbnail: string;
+  duration: number;
+  title: string;
+  artist: string;
+  queuedBy?: Player;
+}
+
+export interface JukeboxArea extends Interactable {
+  songQueue: Song[];
+  elapsedTimeSec: number;
+  timeWhenLastAreaUpdateWasSent: number;
 }
 
 export type TownSettingsUpdate = {
@@ -216,7 +235,8 @@ interface InteractableCommandBase {
   type: string;
 }
 
-export type InteractableCommand =  ViewingAreaUpdateCommand | JoinGameCommand | GameMoveCommand<TicTacToeMove> | GameMoveCommand<ConnectFourMove> | StartGameCommand | LeaveGameCommand;
+export type InteractableCommand =  ViewingAreaUpdateCommand | JoinGameCommand | GameMoveCommand<TicTacToeMove> | GameMoveCommand<ConnectFourMove> | StartGameCommand | LeaveGameCommand
+| JukeboxAreaUpdateCommand | SearchSongCommand | QueueSongCommand | InitiateSongSkipVoteCommand | VoteForSongSkipCommand;
 export interface ViewingAreaUpdateCommand  {
   type: 'ViewingAreaUpdate';
   update: ViewingArea;
@@ -236,6 +256,35 @@ export interface GameMoveCommand<MoveType> {
   type: 'GameMove';
   gameID: GameInstanceID;
   move: MoveType;
+}
+export interface JukeboxAreaUpdateCommand {
+  type: 'JukeboxAreaUpdate';
+  update: JukeboxArea;
+}
+/**
+ * Will need to check for an empty search and return error
+ */
+export interface SearchSongCommand {
+  type: 'SearchSong';
+  title?: string;
+  artist?: string;
+  durationUpperBound?: number;
+  durationLowerBound?: number;
+}
+export interface QueueSongCommand {
+  type: 'QueueSong';
+  url: string;
+  player: Player;
+}
+export interface InitiateSongSkipVoteCommand {
+  type: 'InitiateSongSkipVote';
+  song: Song;
+  player: Player;
+}
+export interface VoteForSongSkipCommand {
+  type: 'VoteForSongSKip';
+  song: Song;
+  skipThisSong: boolean;
 }
 export type InteractableCommandReturnType<CommandType extends InteractableCommand> = 
   CommandType extends JoinGameCommand ? { gameID: string}:

--- a/townService/package.json
+++ b/townService/package.json
@@ -27,7 +27,7 @@
     "build:live": "concurrently \"nodemon --watch 'src/**/*.ts' --watch 'generated/routes.ts' src/Server.ts\" \"nodemon --watch 'src/' --ext ts -x tsoa spec-and-routes\"",
     "swagger": "tsoa spec",
     "format": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "stryker-prepare": "replace-in-file '/../../..//g' '../../../../../' src/types/CoveyTownSocket.d.ts --isRegex"
   },
   "keywords": [],

--- a/townService/src/town/JukeboxAreaController.test.ts
+++ b/townService/src/town/JukeboxAreaController.test.ts
@@ -1,0 +1,128 @@
+import { mock, mockClear } from 'jest-mock-extended';
+import { nanoid } from 'nanoid';
+import Player from '../lib/Player';
+import JukeboxAreaController from '../town/JukeboxAreaController';
+import { defaultLocation, getLastEmittedEvent } from '../TestUtils';
+import { TownEmitter } from '../types/CoveyTownSocket';
+import {
+  JukeboxArea,
+  InteractableCommand,
+  Song,
+  ServerToClientEvents,
+  SocketData,
+} from '../types/CoveyTownSocket';
+import { ITiledMapObject } from '@jonbell/tiled-map-type-guard';
+
+describe('JukeboxAreaController', () => {
+  const id = nanoid();
+  const boundingBox = { x: 100, y: 100, width: 100, height: 100 };
+  const townEmitter = mock<TownEmitter>();
+  let jukeboxArea: JukeboxAreaController;
+  let player: Player;
+
+  beforeEach(() => {
+    mockClear(townEmitter);
+    const jukeboxModel: JukeboxArea = {
+      id,
+      type: 'JukeboxArea',
+      songQueue: [],
+      elapsedTimeSec: 0,
+      occupants: [],
+      timeWhenLastAreaUpdateWasSent: 0,
+    };
+    jukeboxArea = new JukeboxAreaController(id, jukeboxModel, boundingBox, townEmitter);
+    player = new Player(nanoid(), mock<TownEmitter>());
+  });
+
+  describe('add and remove players', () => {
+    it('adds a player to occupantsByID and updates their location', () => {
+      jukeboxArea.add(player);
+      expect(jukeboxArea.occupantsByID).toEqual([player.id]);
+      const lastMove = getLastEmittedEvent(townEmitter, 'playerMoved');
+      expect(lastMove.location.interactableID).toEqual(id);
+    });
+
+    it('removes a player from occupantsByID and clears location', () => {
+      jukeboxArea.add(player);
+      mockClear(townEmitter);
+      jukeboxArea.remove(player);
+      expect(jukeboxArea.occupantsByID).toEqual([]);
+      const lastMove = getLastEmittedEvent(townEmitter, 'playerMoved');
+      expect(lastMove.location.interactableID).toBeUndefined();
+    });
+  });
+
+  describe('song queue management', () => {
+    it('queues a song correctly via command', () => {
+      const command: InteractableCommand = {
+        type: 'QueueSong',
+        url: 'https://example.com/song.mp3',
+        player: player.id,
+        interactableID: id,
+        commandID: nanoid(),
+      } as any;
+      jukeboxArea.handleCommand(command, player);
+      expect(jukeboxArea.songQueue.length).toBe(1);
+      expect(jukeboxArea.songQueue[0].url).toBe('https://example.com/song.mp3');
+      expect(jukeboxArea.songQueue[0].queuedBy).toBe(player.id);
+    });
+
+    it('updates elapsedTimeSec via command', () => {
+      const command: InteractableCommand = {
+        type: 'JukeboxAreaUpdate',
+        update: { elapsedTimeSec: 42 },
+        interactableID: id,
+        commandID: nanoid(),
+      } as any;
+      jukeboxArea.handleCommand(command, player);
+      expect(jukeboxArea.elapsedTimeSec).toBe(42);
+    });
+
+    it('updates entire song queue via command', () => {
+      const command: InteractableCommand = {
+        type: 'JukeboxAreaUpdate',
+        update: { songQueue: [{ url: 'a', queuedBy: player.id, title: '', artist: '', thumbnail: '', duration: 0 }] },
+        interactableID: id,
+        commandID: nanoid(),
+      } as any;
+      jukeboxArea.handleCommand(command, player);
+      expect(jukeboxArea.songQueue.length).toBe(1);
+      expect(jukeboxArea.songQueue[0].url).toBe('a');
+    });
+  });
+
+  describe('toModel', () => {
+    it('returns the correct model with occupants as string[]', () => {
+      jukeboxArea.add(player);
+      const model = jukeboxArea.toModel();
+      expect(model.occupants).toEqual([player.id]);
+      expect(model.songQueue).toEqual(jukeboxArea.songQueue);
+      expect(model.type).toBe('JukeboxArea');
+    });
+  });
+
+  describe('fromMapObject factory', () => {
+    it('creates a JukeboxAreaController from a map object', () => {
+      const mapObject: ITiledMapObject = {
+  id: 1,
+  name: 'jukebox1',
+  type: 'JukeboxArea',
+  x: 10,
+  y: 20,
+  width: 30,
+  height: 40,
+  rotation: 0,
+  visible: true,
+  gid: undefined,
+  properties: [],
+  class: undefined,
+  template: undefined,
+};
+      const area = JukeboxAreaController.fromMapObject(mapObject, townEmitter);
+      expect(area).toBeInstanceOf(JukeboxAreaController);
+      expect(area.toModel().id).toBe('jukebox1');
+      expect(area.toModel().occupants).toEqual([]);
+      expect(area.toModel().songQueue).toEqual([]);
+    });
+  });
+});

--- a/townService/src/town/JukeboxAreaController.ts
+++ b/townService/src/town/JukeboxAreaController.ts
@@ -1,0 +1,105 @@
+import Player from '../lib/Player';
+import InteractableArea from './InteractableArea';
+import { BroadcastOperator } from 'socket.io';
+import { TownEmitter } from '../types/CoveyTownSocket';
+import {
+  JukeboxArea,
+  InteractableCommand,
+  InteractableCommandReturnType,
+  Song,
+  ServerToClientEvents,
+  SocketData,
+} from '../types/CoveyTownSocket';
+import { ITiledMapObject } from '@jonbell/tiled-map-type-guard';
+
+//Controller for a JukeboxArea. Manages song queue and playback state.
+ 
+export default class JukeboxAreaController extends InteractableArea {
+  private _jukeboxState: JukeboxArea;
+
+  constructor(
+    id: string,
+    jukeboxModel: JukeboxArea,
+    boundingBox: { x: number; y: number; width: number; height: number },
+    townEmitter: BroadcastOperator<ServerToClientEvents, SocketData>,
+  ) {
+    super(id, boundingBox, townEmitter);
+    this._jukeboxState = { ...jukeboxModel };
+  }
+
+  public get songQueue(): Song[] {
+    return this._jukeboxState.songQueue;
+  }
+
+  public get elapsedTimeSec(): number {
+    return this._jukeboxState.elapsedTimeSec;
+  }
+
+  public set elapsedTimeSec(value: number) {
+    this._jukeboxState.elapsedTimeSec = value;
+    this._emitAreaChanged();
+  }
+
+  public override toModel(): JukeboxArea {
+    return {
+      ...this._jukeboxState,
+      occupants: Object.keys(this.occupantsByID), // ensure it's a string[]
+    };
+  }
+
+  public override handleCommand<CommandType extends InteractableCommand>(
+    command: CommandType,
+    player: Player,
+  ): InteractableCommandReturnType<CommandType> {
+    switch (command.type) {
+      case 'JukeboxAreaUpdate':
+        if (command.update.songQueue) {
+          this._jukeboxState.songQueue = command.update.songQueue;
+        }
+        if (typeof command.update.elapsedTimeSec === 'number') {
+          this._jukeboxState.elapsedTimeSec = command.update.elapsedTimeSec;
+        }
+        this._emitAreaChanged();
+        return undefined as InteractableCommandReturnType<CommandType>;
+
+      case 'QueueSong':
+        const newSong: Song = {
+          url: command.url,
+          queuedBy: command.player,
+          title: '',
+          artist: '',
+          thumbnail: '',
+          duration: 0,
+        };
+        this._jukeboxState.songQueue.push(newSong);
+        this._emitAreaChanged();
+        return undefined as InteractableCommandReturnType<CommandType>;
+
+      case 'InitiateSongSkipVote':
+      case 'VoteForSongSKip':
+      case 'SearchSong':
+      
+        return undefined as InteractableCommandReturnType<CommandType>;
+
+      default:
+        return undefined as InteractableCommandReturnType<CommandType>;
+    }
+  }
+
+  static fromMapObject(
+  mapObject: ITiledMapObject,
+  townEmitter: TownEmitter,
+): JukeboxAreaController {
+  const { x = 0, y = 0, width = 0, height = 0, name } = mapObject;
+  const boundingBox = { x, y, width, height };
+  const jukeboxModel: JukeboxArea = {
+    id: name,
+    type: 'JukeboxArea',
+    songQueue: [],
+    elapsedTimeSec: 0,
+    occupants: [],
+    timeWhenLastAreaUpdateWasSent: 0,
+  };
+  return new JukeboxAreaController(name, jukeboxModel, boundingBox, townEmitter);
+}
+}

--- a/townService/src/town/Town.ts
+++ b/townService/src/town/Town.ts
@@ -4,6 +4,7 @@ import { BroadcastOperator } from 'socket.io';
 import InvalidParametersError from '../lib/InvalidParametersError';
 import IVideoClient from '../lib/IVideoClient';
 import Player from '../lib/Player';
+import JukeboxArea from './JukeboxAreaController'; //task 8: jukebox area addition
 import TwilioVideo from '../lib/TwilioVideo';
 import { isViewingArea } from '../TestUtils';
 import {
@@ -23,6 +24,7 @@ import ConversationArea from './ConversationArea';
 import GameAreaFactory from './games/GameAreaFactory';
 import InteractableArea from './InteractableArea';
 import ViewingArea from './ViewingArea';
+import JukeboxAreaController from './JukeboxAreaController';
 
 /**
  * The Town class implements the logic for each town: managing the various events that
@@ -411,7 +413,12 @@ export default class Town {
       .map(eachViewingAreaObject =>
         ViewingArea.fromMapObject(eachViewingAreaObject, this._broadcastEmitter),
       );
-
+      //task 8: jukebox area addition
+    const jukeboxAreas = objectLayer.objects
+      .filter(obj => obj.type === 'JukeboxArea')
+      .map(obj => JukeboxAreaController.fromMapObject(obj, this._broadcastEmitter));  
+      //end task 8
+      
     const conversationAreas = objectLayer.objects
       .filter(eachObject => eachObject.type === 'ConversationArea')
       .map(eachConvAreaObj =>
@@ -424,6 +431,7 @@ export default class Town {
 
     this._interactables = this._interactables
       .concat(viewingAreas)
+      .concat(jukeboxAreas)
       .concat(conversationAreas)
       .concat(gameAreas);
     this._validateInteractables();


### PR DESCRIPTION
-Implements JukeBoxAreaController for managing jukebox area, song queues and player interactions
-Adds fromMapObject method for tiled map instantiation
-Handles commands: QueueSong, JukeboxAreaUpdate, InitiateSongSkipVote, VoteForSongSkip, SearchSong
-Adds integration tests
-Fulfills tasks 8 and 8a of project plan