### PR TITLE
feat: Implement player emote relay

### DIFF
--- a/shared/types/CoveyTownSocket.d.ts
+++ b/shared/types/CoveyTownSocket.d.ts
@@ -261,6 +261,7 @@ export interface ServerToClientEvents {
   chatMessage: (message: ChatMessage) => void;
   interactableUpdate: (interactable: Interactable) => void;
   commandResponse: (response: InteractableCommandResponse) => void;
+  onEmote: (data: { playerID: PlayerID; emoteID: string }) => void;
 }
 
 export interface ClientToServerEvents {
@@ -268,4 +269,5 @@ export interface ClientToServerEvents {
   playerMovement: (movementData: PlayerLocation) => void;
   interactableUpdate: (update: Interactable) => void;
   interactableCommand: (command: InteractableCommand & InteractableCommandBase) => void;
+  playerEmote: (data: { playerID: PlayerID; emoteID: string }) => void;
 }

--- a/shared/types/CoveyTownSocket.d.ts
+++ b/shared/types/CoveyTownSocket.d.ts
@@ -58,6 +58,11 @@ export type ChatMessage = {
   interactableID?: string;
 };
 
+export type EmoteData = {
+  playerID: PlayerID;
+  emoteID: string;
+};
+
 export interface ConversationArea extends Interactable {
   topic?: string;
 };
@@ -261,7 +266,7 @@ export interface ServerToClientEvents {
   chatMessage: (message: ChatMessage) => void;
   interactableUpdate: (interactable: Interactable) => void;
   commandResponse: (response: InteractableCommandResponse) => void;
-  onEmote: (data: { playerID: PlayerID; emoteID: string }) => void;
+  onEmote: (data: EmoteData) => void;
 }
 
 export interface ClientToServerEvents {
@@ -269,5 +274,5 @@ export interface ClientToServerEvents {
   playerMovement: (movementData: PlayerLocation) => void;
   interactableUpdate: (update: Interactable) => void;
   interactableCommand: (command: InteractableCommand & InteractableCommandBase) => void;
-  playerEmote: (data: { playerID: PlayerID; emoteID: string }) => void;
+  playerEmote: (data: EmoteData) => void;
 }

--- a/townService/src/town/Town.test.ts
+++ b/townService/src/town/Town.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../TestUtils';
 import {
   ChatMessage,
+  EmoteData,
   Interactable,
   PlayerID,
   PlayerLocation,
@@ -554,6 +555,28 @@ describe('Town', () => {
         expect(player.location).toEqual(newLocation);
       });
     });
+
+    describe('playerEmote', () => {
+      it("Emits playerEmote event",  () => {
+        const emoteHandler = getEventListener(playerTestData.socket, 'playerEmote');
+        const emote: EmoteData = {
+          playerID: player.id,
+          emoteID: "Emotechecking"
+        };
+
+        emoteHandler(emote);
+
+        const emittedEmote = getLastEmittedEvent(townEmitter, 'onEmote')
+        expect(emittedEmote).toEqual(emote)
+      });
+      it('does not forward updates to the ENTIRE town', () => {
+        expect(
+          // getLastEmittedEvent will throw an error if no event was emitted, which we expect to be the case here
+          () => getLastEmittedEvent(townEmitter, 'onEmote'),
+        ).toThrowError();
+      });
+    });
+
     describe('interactableUpdate', () => {
       let interactableUpdateCallback: (update: Interactable) => void;
       let update: ViewingAreaModel;

--- a/townService/src/town/Town.ts
+++ b/townService/src/town/Town.ts
@@ -154,6 +154,14 @@ export default class Town {
       }
     });
 
+    // If player calls emote, emits player ID and emoteID to all clients in the server
+    socket.on('playerEmote', (data: { playerID: string; emoteID: string }) => {
+      this._broadcastEmitter.emit('onEmote', {
+        playerID: data.playerID,
+        emoteID: data.emoteID,
+      });
+    });
+
     // Set up a listener to process updates to interactables.
     // Currently only knows how to process updates for ViewingArea's, and
     // ignores any other updates for any other kind of interactable.


### PR DESCRIPTION
### What does this PR do? 
* This PR adds a new socket listener for the `playerEmote` event. When a client sends this event, the server now relays it as an onEmote event to all other players in the same town.

### Why is this change needed? 
* This allows players to see each other's emotes in real-time, a core component of the emote feature. 

### How was this tested?
* Added a new unit test in `Town.test.ts` to simulate the playerEmote event.
* The test asserts that the `townEmitter` correctly broadcasts the `onEmote` event with the exact same emote data.
* Tests no event is sent when no emote is clicked